### PR TITLE
依存の更新

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim AS base
+FROM eclipse-temurin:17-jdk-alpine AS base
 
 #for compose.override
 FROM base AS dev
@@ -18,7 +18,7 @@ COPY src/ /backend/src/
 RUN ./gradlew shadowJar
 
 
-FROM openjdk:17-slim
+FROM eclipse-temurin:17-jdk-alpine
 
 WORKDIR /backend
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.3'
-    id 'io.spring.dependency-management' version '1.0.12.RELEASE'
+    id 'org.springframework.boot' version '2.7.4'
+    id 'io.spring.dependency-management' version '1.0.14.RELEASE'
     id 'com.github.johnrengelman.shadow' version '7.1.2'
-    id "io.freefair.lombok" version "6.5.0.3"
+    id "io.freefair.lombok" version "6.5.1"
     id 'java'
 }
 
@@ -30,8 +30,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'dev.akkinoc.spring.boot:logback-access-spring-boot-starter:3.3.2'
-    implementation 'org.springdoc:springdoc-openapi-ui:1.6.10'
+    implementation 'dev.akkinoc.spring.boot:logback-access-spring-boot-starter:3.4.0'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 


### PR DESCRIPTION
ユーザ視点の挙動が変わってなければOK

## したこと
### `build.gradle`の依存更新
dependabotに指摘されていた依存を更新

### dockerで使うjdk imageの変更
今まで使っていたopenjdkがdeprecatedなので変更
https://hub.docker.com/_/openjdk

変更先は色々あるが，とりあえずtemurinで
